### PR TITLE
Remove ed_sensor_integration dependency

### DIFF
--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -19,7 +19,6 @@ find_package(catkin REQUIRED
             std_msgs
             tf
             voxel_grid
-            ed_sensor_integration
             visualization_msgs
         )
 


### PR DESCRIPTION
Forgotten in tue-robotics/navigation@d7ff6f0ef61c4796123093289361bec764315c10