### PR TITLE
remove ed_sensor_integration from package.xml

### DIFF
--- a/costmap_2d/package.xml
+++ b/costmap_2d/package.xml
@@ -39,7 +39,6 @@
     <build_depend>tf</build_depend>
     <build_depend>visualization_msgs</build_depend>
     <build_depend>voxel_grid</build_depend>
-    <build_depend>ed_sensor_integration</build_depend>
 
     <run_depend>dynamic_reconfigure</run_depend>
     <run_depend>geometry_msgs</run_depend>
@@ -59,7 +58,6 @@
     <run_depend>tf</run_depend>
     <run_depend>visualization_msgs</run_depend>
     <run_depend>voxel_grid</run_depend>
-    <run_depend>ed_sensor_integration</run_depend>
 
     <test_depend>map_server</test_depend>
     <test_depend>rosbag</test_depend>


### PR DESCRIPTION
This dependency is not needed. By removing this, costmap_2d doesn't need to be rebuild that many times. In line with e5fe7d7