### PR TITLE
(base_local_planner) Remove square root from waypoint distance

### DIFF
--- a/base_local_planner/src/goal_functions.cpp
+++ b/base_local_planner/src/goal_functions.cpp
@@ -101,16 +101,14 @@ namespace base_local_planner {
   }
 
   void planFromLookahead(const std::vector<geometry_msgs::PoseStamped>& plan, double lookahead, std::vector<geometry_msgs::PoseStamped>& new_plan){
-    double waypoint_dist_sq_sum = 0;
+    double waypoint_dist_sum = 0;
     unsigned int target_waypoint_index = plan.size() - 1;
-    // lookahead becomes lookahead^2
-    lookahead = lookahead * lookahead;
     for(unsigned int i = 1; i < plan.size(); ++i){
       double x_diff = plan[i].pose.position.x - plan[i-1].pose.position.x;
       double y_diff = plan[i].pose.position.y - plan[i-1].pose.position.y;
-      double waypoint_dist_sq = x_diff * x_diff + y_diff * y_diff;
-      waypoint_dist_sq_sum += sqrt(waypoint_dist_sq);
-      if (waypoint_dist_sq_sum > lookahead)
+      double waypoint_dist = sqrt(x_diff * x_diff + y_diff * y_diff);
+      waypoint_dist_sum += waypoint_dist;
+      if (waypoint_dist_sum > lookahead)
       {
         target_waypoint_index = i;
         break;


### PR DESCRIPTION
Since the lookahead is squared [here](https://github.com/tue-robotics/navigation/blob/75d016626de1df834bb97ecd3618c2d34b9d20c4/base_local_planner/src/goal_functions.cpp#L106-L107), the updated distance should remain squared as well (as the name `waypoint_dist_sq_sum` suggests).