### PR TITLE
include catkin_INCLUDE_DIRS as system

### DIFF
--- a/amcl/CMakeLists.txt
+++ b/amcl/CMakeLists.txt
@@ -50,7 +50,7 @@ catkin_package(
 )
 
 include_directories(include)
-include_directories(${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
+include_directories(SYSTEM ${catkin_INCLUDE_DIRS} ${Boost_INCLUDE_DIRS})
 include_directories(src/include)
 
 check_include_file(unistd.h HAVE_UNISTD_H)

--- a/base_local_planner/CMakeLists.txt
+++ b/base_local_planner/CMakeLists.txt
@@ -33,6 +33,7 @@ find_package(Eigen3 REQUIRED)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include
+    SYSTEM
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
 )

--- a/costmap_2d/CMakeLists.txt
+++ b/costmap_2d/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED COMPONENTS system thread)
 include_directories(
     include
+    SYSTEM
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
     ${Boost_INCLUDE_DIRS}

--- a/dwa_local_planner/CMakeLists.txt
+++ b/dwa_local_planner/CMakeLists.txt
@@ -23,6 +23,7 @@ find_package(Eigen3 REQUIRED)
 remove_definitions(-DDISABLE_LIBUSB-1.0)
 include_directories(
     include
+    SYSTEM
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
     )

--- a/global_planner/CMakeLists.txt
+++ b/global_planner/CMakeLists.txt
@@ -37,6 +37,7 @@ catkin_package(
 
 include_directories(
   include
+  SYSTEM
   ${catkin_INCLUDE_DIRS}
 )
 

--- a/move_base/CMakeLists.txt
+++ b/move_base/CMakeLists.txt
@@ -47,6 +47,7 @@ catkin_package(
 
 include_directories(
     include
+    SYSTEM
     ${catkin_INCLUDE_DIRS}
     ${EIGEN3_INCLUDE_DIRS}
 )


### PR DESCRIPTION
This way dynamic reconfigure includes take priority over catkin_INLCUDE_DIRS, see https://github.com/ros/dynamic_reconfigure/issues/181

Fixes https://github.com/tue-robotics/navigation/issues/34