### PR TITLE
(dwa_local_planner) Make NotMoving params configurable for melodic-devel

### DIFF
--- a/dwa_local_planner/cfg/DWAPlanner.cfg
+++ b/dwa_local_planner/cfg/DWAPlanner.cfg
@@ -29,6 +29,11 @@ gen.add("switch_goal_distance", double_t, 0, "If the distance to the global goal
 gen.add("switch_plan_distance", double_t, 0, "If the distance to the plan is larger, different parameters are selected", 0.5, 0.0, 2.0)
 gen.add("switch_yaw_error", double_t, 0, "If the yaw error of the robot w.r.t. the plan is larger, different parameters are selected", 1.6, 0.0, 3.14)
 
+# Not moving thresholds
+gen.add("not_moving_distance", double_t, 0, "If less distance has been traveled within the not_moving_time_window, the robot is in state NotMoving", 0.01, 0.0)
+gen.add("not_moving_time_window", double_t, 0, "Time window to evaluate whether the robot is in state NotMoving", 10.0, 0.0)
+gen.add("not_moving_minimal_duration", double_t, 0, "The minimal duration the robot stays in the NotMoving state", 5.0, 0.0)
+
 # Cost functions
 gen.add("align_align_scale", double_t, 0, "Align state - align_scale", 1.0, 0)
 gen.add("align_plan_scale", double_t, 0, "Align state - plan_scale", 1.0, 0)

--- a/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
+++ b/dwa_local_planner/include/dwa_local_planner/dwa_planner.h
@@ -168,6 +168,10 @@ namespace dwa_local_planner {
       double switch_plan_distance_;
       double switch_goal_distance_;
 
+      double not_moving_distance_;
+      double not_moving_time_window_;
+      double not_moving_minimal_duration_;
+
       base_local_planner::LocalPlannerUtil *planner_util_;
 
       double stop_time_buffer_; ///< @brief How long before hitting something we're going to enforce that the robot stop

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -78,6 +78,11 @@ namespace dwa_local_planner {
     not_moving_time_window_ = config.not_moving_time_window;
     not_moving_minimal_duration_ = config.not_moving_minimal_duration;
 
+    ROS_INFO_STREAM("notMoving configured:\n"
+                    << "    - Not moving reset distance : " << config.not_moving_distance << " [m]\n"
+                    << "    - Not moving evaluation time window : " << config.not_moving_time_window << " [s]\n"
+                    << "    - Not moving minimal duration : " << config.not_moving_minimal_duration << " [s]\n");
+
     // Set scales
     align_align_scale_ = config.align_align_scale;
     align_plan_scale_ = config.align_plan_scale;

--- a/dwa_local_planner/src/dwa_planner.cpp
+++ b/dwa_local_planner/src/dwa_planner.cpp
@@ -73,6 +73,11 @@ namespace dwa_local_planner {
                     << "    - Goal distance : " << config.switch_goal_distance << " [m]\n"
                     << "    - Plan distance : " << config.switch_plan_distance << " [m]\n");
 
+    // Set not moving thresholds
+    not_moving_distance_ = config.not_moving_distance;
+    not_moving_time_window_ = config.not_moving_time_window;
+    not_moving_minimal_duration_ = config.not_moving_minimal_duration;
+
     // Set scales
     align_align_scale_ = config.align_align_scale;
     align_plan_scale_ = config.align_plan_scale;
@@ -363,25 +368,25 @@ namespace dwa_local_planner {
     bool is_moving = false;
 
     // Check whether we're actually moving
-    if (dist_sq > 0.01) {
+    if (dist_sq > not_moving_distance_) {
       resetMotionStamp();
       x_saved = x;
       y_saved = y;
       is_moving = true;
     }
 
-    if (!prev_is_moving && time_since_stop < 5.0) {
-      // Make sure we are always 'notMoving' for at least 5 seconds to avoid switching behavior
+    if (!prev_is_moving && time_since_stop < not_moving_minimal_duration_) {
+      // Configure the minimal 'notMoving' duration to avoid switching behavior
       return false;
     }
     else if (is_moving) {
       prev_is_moving = true;
       return true;
     }
-    else if ( time_since_move > 10.0) {
+    else if ( time_since_move > not_moving_time_window_) {
       if (prev_is_moving)
       {
-        ROS_WARN("Robot has not moved significantly for more than 10 seconds");
+        ROS_WARN("Robot has not moved significantly for more than %f seconds", not_moving_time_window_);
         stamp_not_moving = ros::Time::now();
         prev_is_moving = false;
       }


### PR DESCRIPTION
Replaces the magic numbers regarding the NotMoving state thresholds for dynamically reconfigurable parameters